### PR TITLE
fix(firestore): use pooled HTTP/2 connections by default to fix slow/failing concurrent requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,7 +234,7 @@ jobs:
       - name: Upload coverage to codecov
         if: matrix.dart-version == 'stable'
         continue-on-error: true
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
+        uses: codecov/codecov-action@v4
         with:
           files: coverage.lcov
           flags: unittests

--- a/packages/google_cloud_firestore/CHANGELOG.md
+++ b/packages/google_cloud_firestore/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Updated `Transaction.delete` and `Transaction.update` type constraints to accept `DocumentReference<Object?>`. (thanks to @Levin-Me)
 - Made `Timestamp` encodable by adding `toJson` method. (thanks to @OutdatedGuy)
 - Update dependency `googleapis_auth: ^2.3.3` to fix `auth/insufficient-permission` errors with Application Default Credentials that have no quota project set.
+- Fixed slow and failing requests under high concurrency by pooling shared HTTP/2 connections by default instead of opening a new HTTP/1.1 connection per request.
 
 ## 0.5.2
 

--- a/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
@@ -104,10 +104,13 @@ Future<StreamedResponse> _sendOverHttp2(
   if (bodyBytes.isNotEmpty) stream.sendData(bodyBytes, endStream: true);
 
   final statusCompleter = Completer<int>();
-  final bodyController = StreamController<List<int>>();
+  late final StreamSubscription<StreamMessage> subscription;
+  final bodyController = StreamController<List<int>>(
+    onCancel: () => subscription.cancel(),
+  );
   final responseHeaders = <String, String>{};
 
-  stream.incomingMessages.listen(
+  subscription = stream.incomingMessages.listen(
     (message) {
       if (message is HeadersStreamMessage) {
         for (final header in message.headers) {
@@ -237,7 +240,12 @@ class ClientPool<T> {
     if (!resource.failed && !_hasExcessIdleCapacity) return;
 
     _resources.remove(resource);
-    await _destroy(await resource.future);
+    try {
+      await _destroy(await resource.future);
+    } catch (_) {
+      // Best-effort: a failure here must not shadow the caller's own
+      // request error, since this runs inside run()'s finally block.
+    }
   }
 
   bool get _hasExcessIdleCapacity {
@@ -319,8 +327,14 @@ class Http2ClientPool extends BaseClient {
   Future<StreamedResponse> send(BaseRequest request) =>
       _pool.run((transport) => _sendOverHttp2(transport, request));
 
+  /// Waits for in-flight requests to finish, then closes every connection.
+  ///
+  /// Unlike [close] (constrained by `http.Client`'s synchronous signature),
+  /// this can be awaited by callers who hold a concrete [Http2ClientPool].
+  Future<void> terminate() => _pool.terminate();
+
   @override
-  void close() => unawaited(_pool.terminate());
+  void close() => unawaited(terminate());
 }
 
 /// HTTP client wrapper for Firestore API operations.
@@ -461,6 +475,6 @@ class FirestoreHttpClient {
   Future<void> close() async {
     final client = await _client;
     client.close();
-    _transport?.close();
+    await _transport?.terminate();
   }
 }

--- a/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
@@ -337,6 +337,37 @@ class Http2ClientPool extends BaseClient {
   void close() => unawaited(terminate());
 }
 
+/// Routes requests to [pooledHost] through [pooled]; everything else -
+/// credential negotiation, WIF/OIDC token exchange, metadata server calls -
+/// falls through to [fallback], since those target hosts the single-host
+/// [pooled] transport was never dialed for.
+class _HostRoutingClient extends BaseClient {
+  _HostRoutingClient(this.pooledHost, this.pooled, this.fallback);
+
+  final String pooledHost;
+  final Http2ClientPool pooled;
+  final Client fallback;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) {
+    if (request.url.host == pooledHost) {
+      return pooled.send(request);
+    }
+    return fallback.send(request);
+  }
+
+  @override
+  void close() {
+    pooled.close();
+    fallback.close();
+  }
+
+  Future<void> terminate() async {
+    await pooled.terminate();
+    fallback.close();
+  }
+}
+
 /// HTTP client wrapper for Firestore API operations.
 ///
 /// Provides authenticated API access with automatic project ID discovery.
@@ -416,7 +447,7 @@ class FirestoreHttpClient {
 
   // googleapis_auth never closes a caller-supplied baseClient, so
   // close() must reach this transport itself.
-  Http2ClientPool? _transport;
+  _HostRoutingClient? _transport;
 
   /// Creates the appropriate HTTP client based on emulator configuration.
   Future<googleapis_auth.AuthClient> _createClient() async {
@@ -426,9 +457,8 @@ class FirestoreHttpClient {
       return EmulatorClient(Client());
     }
 
-    final transport = Http2ClientPool(
-      _settings.host ?? 'firestore.googleapis.com',
-    );
+    final host = _settings.host ?? 'firestore.googleapis.com';
+    final transport = _HostRoutingClient(host, Http2ClientPool(host), Client());
     _transport = transport;
 
     final serviceAccountCreds = credential.serviceAccountCredentials;

--- a/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
@@ -346,8 +346,12 @@ class FirestoreHttpClient {
   /// Creates the appropriate HTTP client based on emulator configuration.
   Future<googleapis_auth.AuthClient> _createClient() async {
     if (_isUsingEmulator) {
-      // Emulator: Create unauthenticated client. The emulator has no TLS
-      // and doesn't negotiate HTTP/2, so this stays on plain HTTP/1.1.
+      // Emulator: plain HTTP/1.1, matching nodejs-firestore's own REST-mode
+      // behavior for the emulator (it forces `protocol: 'http'` when ssl is
+      // false in REST fallback - see index.ts's clientFactory). Node's
+      // gRPC-mode client does use HTTP/2 for the emulator, but that's a
+      // separate transport with no equivalent here - our SDK is REST-only,
+      // so its REST-mode behavior is the correct comparison, not gRPC's.
       return EmulatorClient(Client());
     }
 

--- a/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
@@ -81,80 +81,6 @@ class EmulatorClient extends BaseClient implements googleapis_auth.AuthClient {
   void close() => client.close();
 }
 
-/// Sends [request] as a single HTTP/2 stream on [transport], translating
-/// between `BaseRequest`/`StreamedResponse` and http2's frames.
-Future<StreamedResponse> _sendOverHttp2(
-  ClientTransportConnection transport,
-  BaseRequest request,
-) async {
-  final bodyBytes = await request.finalize().toBytes();
-  final path = request.url.hasQuery
-      ? '${request.url.path}?${request.url.query}'
-      : request.url.path;
-
-  final stream = transport.makeRequest([
-    Header.ascii(':method', request.method),
-    Header.ascii(':scheme', 'https'),
-    Header.ascii(':authority', request.url.host),
-    Header.ascii(':path', path),
-    for (final entry in request.headers.entries)
-      Header.ascii(entry.key.toLowerCase(), entry.value),
-  ], endStream: bodyBytes.isEmpty);
-
-  if (bodyBytes.isNotEmpty) stream.sendData(bodyBytes, endStream: true);
-
-  final statusCompleter = Completer<int>();
-  late final StreamSubscription<StreamMessage> subscription;
-  final bodyController = StreamController<List<int>>(
-    onCancel: () => subscription.cancel(),
-  );
-  final responseHeaders = <String, String>{};
-
-  subscription = stream.incomingMessages.listen(
-    (message) {
-      if (message is HeadersStreamMessage) {
-        for (final header in message.headers) {
-          final name = ascii.decode(header.name);
-          final value = ascii.decode(header.value);
-          if (name == ':status') {
-            if (!statusCompleter.isCompleted) {
-              statusCompleter.complete(int.parse(value));
-            }
-          } else {
-            responseHeaders[name] = value;
-          }
-        }
-      } else if (message is DataStreamMessage) {
-        bodyController.add(message.bytes);
-      }
-    },
-    onDone: () {
-      if (!statusCompleter.isCompleted) {
-        statusCompleter.completeError(
-          StateError('Stream closed before a response status was received'),
-        );
-      }
-      if (!bodyController.isClosed) bodyController.close();
-    },
-    onError: (Object error, StackTrace stackTrace) {
-      if (!statusCompleter.isCompleted) {
-        statusCompleter.completeError(error, stackTrace);
-      }
-      bodyController.addError(error, stackTrace);
-      if (!bodyController.isClosed) bodyController.close();
-    },
-    cancelOnError: true,
-  );
-
-  final statusCode = await statusCompleter.future;
-  return StreamedResponse(
-    bodyController.stream,
-    statusCode,
-    headers: responseHeaders,
-    request: request,
-  );
-}
-
 class _PooledResource<T> {
   _PooledResource(this.future);
   final Future<T> future;
@@ -319,7 +245,7 @@ class Http2Client extends BaseClient {
     );
   }
 
-  static Future<ClientTransportConnection> _dial(String host) async {
+  Future<ClientTransportConnection> _dial(String host) async {
     final socket = await SecureSocket.connect(
       host,
       443,
@@ -334,14 +260,89 @@ class Http2Client extends BaseClient {
     return ClientTransportConnection.viaSocket(socket);
   }
 
+  /// Sends [request] as a single HTTP/2 stream on [transport], translating
+  /// between `BaseRequest`/`StreamedResponse` and http2's frames.
+  Future<StreamedResponse> _sendOverHttp2(
+    ClientTransportConnection transport,
+    BaseRequest request,
+  ) async {
+    final bodyBytes = await request.finalize().toBytes();
+    final path = request.url.hasQuery
+        ? '${request.url.path}?${request.url.query}'
+        : request.url.path;
+
+    final stream = transport.makeRequest([
+      Header.ascii(':method', request.method),
+      Header.ascii(':scheme', 'https'),
+      Header.ascii(':authority', request.url.host),
+      Header.ascii(':path', path),
+      for (final entry in request.headers.entries)
+        Header.ascii(entry.key.toLowerCase(), entry.value),
+    ], endStream: bodyBytes.isEmpty);
+
+    if (bodyBytes.isNotEmpty) stream.sendData(bodyBytes, endStream: true);
+
+    final statusCompleter = Completer<int>();
+    late final StreamSubscription<StreamMessage> subscription;
+    final bodyController = StreamController<List<int>>(
+      onCancel: () => subscription.cancel(),
+    );
+    final responseHeaders = <String, String>{};
+
+    subscription = stream.incomingMessages.listen(
+      (message) {
+        if (message is HeadersStreamMessage) {
+          for (final header in message.headers) {
+            final name = ascii.decode(header.name);
+            final value = ascii.decode(header.value);
+            if (name == ':status') {
+              if (!statusCompleter.isCompleted) {
+                statusCompleter.complete(int.parse(value));
+              }
+            } else {
+              responseHeaders[name] = value;
+            }
+          }
+        } else if (message is DataStreamMessage) {
+          bodyController.add(message.bytes);
+        }
+      },
+      onDone: () {
+        if (!statusCompleter.isCompleted) {
+          statusCompleter.completeError(
+            StateError('Stream closed before a response status was received'),
+          );
+        }
+        if (!bodyController.isClosed) bodyController.close();
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        if (!statusCompleter.isCompleted) {
+          statusCompleter.completeError(error, stackTrace);
+        }
+        bodyController.addError(error, stackTrace);
+        if (!bodyController.isClosed) bodyController.close();
+      },
+      cancelOnError: true,
+    );
+
+    final statusCode = await statusCompleter.future;
+    return StreamedResponse(
+      bodyController.stream,
+      statusCode,
+      headers: responseHeaders,
+      request: request,
+    );
+  }
+
   /// The number of connections currently pooled, across all hosts.
   int get connectionCount =>
       _pools.values.fold(0, (total, pool) => total + pool.size);
 
   @override
-  Future<StreamedResponse> send(BaseRequest request) => _poolFor(
-    request.url.host,
-  ).run((transport) => _sendOverHttp2(transport, request));
+  Future<StreamedResponse> send(BaseRequest request) =>
+      _poolFor(request.url.host).run(
+        (transport) => _sendOverHttp2(transport, request),
+      );
 
   /// Waits for in-flight requests to finish, then closes every connection.
   ///

--- a/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
@@ -146,124 +146,169 @@ Future<StreamedResponse> _sendOverHttp2(
   );
 }
 
-class _PooledConnection {
-  _PooledConnection(this.transportFuture);
-  final Future<ClientTransportConnection> transportFuture;
+class _PooledResource<T> {
+  _PooledResource(this.future);
+  final Future<T> future;
   int inFlight = 0;
-
-  /// Set once a send() on this connection throws - matches Node
-  /// ClientPool's RST_STREAM handling: stop routing NEW work here, but let
-  /// requests already in flight finish. Actually removing/closing failed
-  /// connections is deferred (see [Http2ClientPool] doc comment) - this
-  /// pass only stops reusing them.
   bool failed = false;
 }
 
-/// Sends every request as a stream on a pool of shared HTTP/2 connections
-/// to [host], mirroring nodejs-firestore's `ClientPool`
-/// (dev/src/pool.ts): packs load onto the most-full connection under
-/// [maxStreamsPerConnection] (to keep others idle) rather than spreading
-/// evenly, opens a new connection once all existing ones are full, and
-/// stops routing new work to a connection once it's shown a
-/// connection-level failure.
-///
-/// Known gaps vs. Node's ClientPool, deferred to a follow-up:
-/// - No idle-capacity garbage collection - connections opened during a
-///   burst are never closed once traffic quiets down.
-/// - No graceful terminate() draining - close() does not wait for
-///   in-flight requests before finishing connections.
-///
-/// Pure transport: no auth. Wrapped with googleapis_auth's client helpers
-/// below (see [FirestoreHttpClient._createClient]) for a refreshing
-/// AuthClient.
-class Http2ClientPool extends BaseClient {
-  Http2ClientPool(this.host, {this.maxStreamsPerConnection = 100})
-    : _handshakeGate = Pool(_maxConcurrentHandshakes);
+/// A pool of resources of type [T], mirroring nodejs-firestore's
+/// `ClientPool` (dev/src/pool.ts): packs load onto the most-full resource
+/// under [maxConcurrentOperations] instead of spreading evenly, opens a
+/// new resource once existing ones are full, retires a resource once
+/// [run] reports it failed, and garbage collects idle resources past
+/// [maxIdleResources].
+@internal
+class ClientPool<T> {
+  ClientPool(
+    Future<T> Function() create, {
+    required this.maxConcurrentOperations,
+    required Future<void> Function(T resource) destroy,
+    this.maxIdleResources = 1,
+  }) : _create = create,
+       _destroy = destroy;
 
-  final String host;
-  final int maxStreamsPerConnection;
+  final Future<T> Function() _create;
+  final Future<void> Function(T resource) _destroy;
+  final int maxConcurrentOperations;
+  final int maxIdleResources;
 
-  // Caps concurrent in-flight TCP+TLS handshakes, independent of how many
-  // total connections the pool ends up needing - protects against a huge,
-  // unpredictable production burst opening hundreds of handshakes at once.
-  static const _maxConcurrentHandshakes = 50;
-  final Pool _handshakeGate;
+  final _resources = <_PooledResource<T>>[];
+  var _terminated = false;
+  Completer<void>? _drained;
 
-  final List<_PooledConnection> _connections = [];
+  @visibleForTesting
+  int get size => _resources.length;
 
-  Future<ClientTransportConnection> _openConnection() {
-    return _handshakeGate.withResource(() async {
-      final socket = await SecureSocket.connect(
-        host,
-        443,
-        supportedProtocols: ['h2'],
-      );
-      if (socket.selectedProtocol != 'h2') {
-        throw StateError(
-          'Server did not negotiate HTTP/2 (got ${socket.selectedProtocol})',
-        );
+  @visibleForTesting
+  int get opCount =>
+      _resources.fold(0, (total, resource) => total + resource.inFlight);
+
+  /// Runs [operation] on an available (or newly created) resource.
+  Future<R> run<R>(Future<R> Function(T resource) operation) async {
+    if (_terminated) {
+      throw StateError('This pool has already been terminated.');
+    }
+
+    final pooled = _acquire();
+    pooled.inFlight++;
+    try {
+      return await operation(await pooled.future);
+    } catch (_) {
+      pooled.failed = true;
+      rethrow;
+    } finally {
+      pooled.inFlight--;
+      if (_terminated) {
+        _maybeCompleteDrain();
+      } else {
+        await _collectIfIdle(pooled);
       }
-      return ClientTransportConnection.viaSocket(socket);
-    });
+    }
   }
 
-  /// Picks the most-full connection under capacity, or reserves a new one.
-  ///
-  /// Deliberately synchronous (no `await`), so it runs atomically with
-  /// respect to other concurrent calls without needing a lock - otherwise
-  /// many callers arriving before the first connection finishes dialing
-  /// would all see an empty pool and each open their own (a thundering
-  /// herd), instead of piling onto the one already being established.
-  ///
-  /// "Most-full" (not least-loaded) selection matches Node ClientPool's
-  /// intent: pack load onto fewer connections so others stay idle and
-  /// become eligible for future cleanup, rather than spreading evenly.
-  _PooledConnection _acquireConnection() {
-    _PooledConnection? selected;
-    for (final conn in _connections) {
-      if (conn.failed) continue;
-      if (conn.inFlight < maxStreamsPerConnection &&
-          (selected == null || conn.inFlight > selected.inFlight)) {
-        selected = conn;
+  // Synchronous (no `await`), so concurrent calls can't race each other
+  // into both creating a resource before either sees the other's.
+  _PooledResource<T> _acquire() {
+    _PooledResource<T>? selected;
+    for (final resource in _resources) {
+      if (resource.failed) continue;
+      if (resource.inFlight < maxConcurrentOperations &&
+          (selected == null || resource.inFlight > selected.inFlight)) {
+        selected = resource;
       }
     }
     if (selected != null) return selected;
 
-    final pooled = _PooledConnection(_openConnection());
-    _connections.add(pooled);
-    return pooled;
+    final resource = _PooledResource<T>(_create());
+    _resources.add(resource);
+    return resource;
   }
 
-  /// The number of connections currently in the pool (including any that
-  /// have been marked [_PooledConnection.failed] but not yet cleaned up).
-  int get connectionCount => _connections.length;
+  Future<void> _collectIfIdle(_PooledResource<T> resource) async {
+    if (resource.inFlight > 0) return;
+    if (!resource.failed && !_hasExcessIdleCapacity) return;
 
-  @override
-  Future<StreamedResponse> send(BaseRequest request) async {
-    final conn = _acquireConnection();
-    conn.inFlight++;
-    try {
-      final transport = await conn.transportFuture;
-      return await _sendOverHttp2(transport, request);
-    } catch (e) {
-      // Broader than Node's RST_STREAM-specific regex match - our own
-      // testing surfaced multiple distinct http2-level error shapes
-      // (REFUSED_STREAM, "forcefully terminated"/CONNECT_ERROR), so any
-      // thrown error here is treated as a signal this connection is no
-      // longer trustworthy for new work.
-      conn.failed = true;
-      rethrow;
-    } finally {
-      conn.inFlight--;
+    _resources.remove(resource);
+    await _destroy(await resource.future);
+  }
+
+  bool get _hasExcessIdleCapacity {
+    final idleCapacity = _resources.fold(
+      0,
+      (total, resource) => total + (maxConcurrentOperations - resource.inFlight),
+    );
+    return idleCapacity > maxIdleResources * maxConcurrentOperations;
+  }
+
+  void _maybeCompleteDrain() {
+    final drained = _drained;
+    if (drained != null && !drained.isCompleted && opCount == 0) {
+      drained.complete();
     }
   }
 
-  @override
-  void close() {
-    for (final conn in _connections) {
-      conn.transportFuture.then((t) => t.finish());
+  /// Waits for in-flight operations to finish, then destroys every
+  /// resource in the pool. No further operations can run afterward.
+  Future<void> terminate() async {
+    _terminated = true;
+
+    if (opCount > 0) {
+      _drained = Completer<void>();
+      await _drained!.future;
     }
+
+    for (final resource in _resources) {
+      await _destroy(await resource.future);
+    }
+    _resources.clear();
   }
+}
+
+/// Sends every request as a stream on a pool of shared HTTP/2 connections
+/// to [host] - see [ClientPool]. Pure transport, no auth: wrapped with
+/// googleapis_auth's client helpers in [FirestoreHttpClient._createClient]
+/// for a refreshing [googleapis_auth.AuthClient].
+class Http2ClientPool extends BaseClient {
+  Http2ClientPool(this.host, {this.maxStreamsPerConnection = 100})
+    : _pool = ClientPool<ClientTransportConnection>(
+        () => _handshakeGate.withResource(() => _dial(host)),
+        maxConcurrentOperations: maxStreamsPerConnection,
+        destroy: (transport) => transport.finish(),
+      );
+
+  final String host;
+  final int maxStreamsPerConnection;
+  final ClientPool<ClientTransportConnection> _pool;
+
+  // Caps concurrent in-flight TCP+TLS handshakes across all pools,
+  // independent of how many total connections any one pool needs.
+  static final _handshakeGate = Pool(50);
+
+  static Future<ClientTransportConnection> _dial(String host) async {
+    final socket = await SecureSocket.connect(
+      host,
+      443,
+      supportedProtocols: ['h2'],
+    );
+    if (socket.selectedProtocol != 'h2') {
+      throw StateError(
+        'Server did not negotiate HTTP/2 (got ${socket.selectedProtocol})',
+      );
+    }
+    return ClientTransportConnection.viaSocket(socket);
+  }
+
+  /// The number of connections currently in the pool.
+  int get connectionCount => _pool.size;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) =>
+      _pool.run((transport) => _sendOverHttp2(transport, request));
+
+  @override
+  void close() => unawaited(_pool.terminate());
 }
 
 /// HTTP client wrapper for Firestore API operations.
@@ -343,23 +388,22 @@ class FirestoreHttpClient {
   /// Lazy-initialized HTTP client that's cached for reuse.
   late final Future<googleapis_auth.AuthClient> _client = _createClient();
 
+  // googleapis_auth never closes a caller-supplied baseClient, so
+  // close() must reach this transport itself.
+  Http2ClientPool? _transport;
+
   /// Creates the appropriate HTTP client based on emulator configuration.
   Future<googleapis_auth.AuthClient> _createClient() async {
     if (_isUsingEmulator) {
-      // Emulator: plain HTTP/1.1, matching nodejs-firestore's own REST-mode
-      // behavior for the emulator (it forces `protocol: 'http'` when ssl is
-      // false in REST fallback - see index.ts's clientFactory). Node's
-      // gRPC-mode client does use HTTP/2 for the emulator, but that's a
-      // separate transport with no equivalent here - our SDK is REST-only,
-      // so its REST-mode behavior is the correct comparison, not gRPC's.
+      // Emulator: plain HTTP/1.1, matching nodejs-firestore's REST-mode
+      // behavior (its gRPC mode uses HTTP/2, but this SDK is REST-only).
       return EmulatorClient(Client());
     }
 
-    // Production: every request multiplexes over a pool of shared HTTP/2
-    // connections instead of dart:io's default one-connection-per-request
-    // HTTP/1.1 behavior. googleapis_auth wraps this transport with its
-    // token-refresh logic - the pool itself has no auth concept.
-    final transport = Http2ClientPool(_settings.host ?? 'firestore.googleapis.com');
+    final transport = Http2ClientPool(
+      _settings.host ?? 'firestore.googleapis.com',
+    );
+    _transport = transport;
 
     final serviceAccountCreds = credential.serviceAccountCredentials;
     if (serviceAccountCreds != null) {
@@ -370,7 +414,6 @@ class FirestoreHttpClient {
       );
     }
 
-    // Fall back to Application Default Credentials
     return googleapis_auth.clientViaApplicationDefaultCredentials(
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
       baseClient: transport,
@@ -406,5 +449,6 @@ class FirestoreHttpClient {
   Future<void> close() async {
     final client = await _client;
     client.close();
+    _transport?.close();
   }
 }

--- a/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
@@ -98,7 +98,7 @@ Future<StreamedResponse> _sendOverHttp2(
     Header.ascii(':authority', request.url.host),
     Header.ascii(':path', path),
     for (final entry in request.headers.entries)
-      Header.ascii(entry.key, entry.value),
+      Header.ascii(entry.key.toLowerCase(), entry.value),
   ], endStream: bodyBytes.isEmpty);
 
   if (bodyBytes.isNotEmpty) stream.sendData(bodyBytes, endStream: true);
@@ -126,6 +126,11 @@ Future<StreamedResponse> _sendOverHttp2(
       }
     },
     onDone: () {
+      if (!statusCompleter.isCompleted) {
+        statusCompleter.completeError(
+          StateError('Stream closed before a response status was received'),
+        );
+      }
       if (!bodyController.isClosed) bodyController.close();
     },
     onError: (Object error, StackTrace stackTrace) {
@@ -133,6 +138,7 @@ Future<StreamedResponse> _sendOverHttp2(
         statusCompleter.completeError(error, stackTrace);
       }
       bodyController.addError(error, stackTrace);
+      if (!bodyController.isClosed) bodyController.close();
     },
     cancelOnError: true,
   );
@@ -260,7 +266,12 @@ class ClientPool<T> {
     }
 
     for (final resource in _resources) {
-      await _destroy(await resource.future);
+      try {
+        await _destroy(await resource.future);
+      } catch (_) {
+        // Best-effort: one resource failing to close shouldn't stop the
+        // rest from being destroyed.
+      }
     }
     _resources.clear();
   }
@@ -293,6 +304,7 @@ class Http2ClientPool extends BaseClient {
       supportedProtocols: ['h2'],
     );
     if (socket.selectedProtocol != 'h2') {
+      socket.destroy();
       throw StateError(
         'Server did not negotiate HTTP/2 (got ${socket.selectedProtocol})',
       );

--- a/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
@@ -285,25 +285,39 @@ class ClientPool<T> {
   }
 }
 
-/// Sends every request as a stream on a pool of shared HTTP/2 connections
-/// to [host] - see [ClientPool]. Pure transport, no auth: wrapped with
-/// googleapis_auth's client helpers in [FirestoreHttpClient._createClient]
-/// for a refreshing [googleapis_auth.AuthClient].
-class Http2ClientPool extends BaseClient {
-  Http2ClientPool(this.host, {this.maxStreamsPerConnection = 100})
-    : _pool = ClientPool<ClientTransportConnection>(
+/// Sends every request as a stream on a pool of shared HTTP/2 connections,
+/// dialed per-host - see [ClientPool]. Multi-host so it's safe to use for
+/// every request an [googleapis_auth.AuthClient] might send, not just the
+/// actual Firestore calls: credential negotiation (OAuth2 token endpoint,
+/// WIF/OIDC token exchange) targets different hosts entirely, and each
+/// gets its own pool dialed to the right place instead of reusing a
+/// connection meant for somewhere else.
+///
+/// Pure transport, no auth: wrapped with googleapis_auth's client helpers
+/// in [FirestoreHttpClient._createClient] for a refreshing
+/// [googleapis_auth.AuthClient].
+class Http2Client extends BaseClient {
+  Http2Client({this.maxStreamsPerConnection = 100});
+
+  final int maxStreamsPerConnection;
+  final _pools = <String, ClientPool<ClientTransportConnection>>{};
+
+  // Caps concurrent in-flight TCP+TLS handshakes across all hosts,
+  // independent of how many total connections any one pool needs.
+  static final _handshakeGate = Pool(50);
+
+  // Synchronous (no `await`), so concurrent requests to a new host can't
+  // race each other into creating two pools for the same host.
+  ClientPool<ClientTransportConnection> _poolFor(String host) {
+    return _pools.putIfAbsent(
+      host,
+      () => ClientPool<ClientTransportConnection>(
         () => _handshakeGate.withResource(() => _dial(host)),
         maxConcurrentOperations: maxStreamsPerConnection,
         destroy: (transport) => transport.finish(),
-      );
-
-  final String host;
-  final int maxStreamsPerConnection;
-  final ClientPool<ClientTransportConnection> _pool;
-
-  // Caps concurrent in-flight TCP+TLS handshakes across all pools,
-  // independent of how many total connections any one pool needs.
-  static final _handshakeGate = Pool(50);
+      ),
+    );
+  }
 
   static Future<ClientTransportConnection> _dial(String host) async {
     final socket = await SecureSocket.connect(
@@ -320,52 +334,27 @@ class Http2ClientPool extends BaseClient {
     return ClientTransportConnection.viaSocket(socket);
   }
 
-  /// The number of connections currently in the pool.
-  int get connectionCount => _pool.size;
+  /// The number of connections currently pooled, across all hosts.
+  int get connectionCount =>
+      _pools.values.fold(0, (total, pool) => total + pool.size);
 
   @override
-  Future<StreamedResponse> send(BaseRequest request) =>
-      _pool.run((transport) => _sendOverHttp2(transport, request));
+  Future<StreamedResponse> send(BaseRequest request) => _poolFor(
+    request.url.host,
+  ).run((transport) => _sendOverHttp2(transport, request));
 
   /// Waits for in-flight requests to finish, then closes every connection.
   ///
   /// Unlike [close] (constrained by `http.Client`'s synchronous signature),
-  /// this can be awaited by callers who hold a concrete [Http2ClientPool].
-  Future<void> terminate() => _pool.terminate();
+  /// this can be awaited by callers who hold a concrete [Http2Client].
+  Future<void> terminate() async {
+    for (final pool in _pools.values) {
+      await pool.terminate();
+    }
+  }
 
   @override
   void close() => unawaited(terminate());
-}
-
-/// Routes requests to [pooledHost] through [pooled]; everything else -
-/// credential negotiation, WIF/OIDC token exchange, metadata server calls -
-/// falls through to [fallback], since those target hosts the single-host
-/// [pooled] transport was never dialed for.
-class _HostRoutingClient extends BaseClient {
-  _HostRoutingClient(this.pooledHost, this.pooled, this.fallback);
-
-  final String pooledHost;
-  final Http2ClientPool pooled;
-  final Client fallback;
-
-  @override
-  Future<StreamedResponse> send(BaseRequest request) {
-    if (request.url.host == pooledHost) {
-      return pooled.send(request);
-    }
-    return fallback.send(request);
-  }
-
-  @override
-  void close() {
-    pooled.close();
-    fallback.close();
-  }
-
-  Future<void> terminate() async {
-    await pooled.terminate();
-    fallback.close();
-  }
 }
 
 /// HTTP client wrapper for Firestore API operations.
@@ -447,7 +436,7 @@ class FirestoreHttpClient {
 
   // googleapis_auth never closes a caller-supplied baseClient, so
   // close() must reach this transport itself.
-  _HostRoutingClient? _transport;
+  Http2Client? _transport;
 
   /// Creates the appropriate HTTP client based on emulator configuration.
   Future<googleapis_auth.AuthClient> _createClient() async {
@@ -457,8 +446,7 @@ class FirestoreHttpClient {
       return EmulatorClient(Client());
     }
 
-    final host = _settings.host ?? 'firestore.googleapis.com';
-    final transport = _HostRoutingClient(host, Http2ClientPool(host), Client());
+    final transport = Http2Client();
     _transport = transport;
 
     final serviceAccountCreds = credential.serviceAccountCredentials;

--- a/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
+++ b/packages/google_cloud_firestore/lib/src/firestore_http_client.dart
@@ -13,13 +13,17 @@
 // limitations under the License.
 
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
 import 'package:google_cloud/constants.dart' as google_cloud;
 import 'package:google_cloud/google_cloud.dart' as google_cloud;
 import 'package:google_cloud_firestore_v1/firestore.dart' as firestore_v1;
 import 'package:googleapis_auth/auth_io.dart' as googleapis_auth;
 import 'package:http/http.dart';
+import 'package:http2/transport.dart' hide Settings;
 import 'package:meta/meta.dart';
+import 'package:pool/pool.dart';
 
 import '../google_cloud_firestore.dart';
 import 'environment.dart';
@@ -75,6 +79,191 @@ class EmulatorClient extends BaseClient implements googleapis_auth.AuthClient {
 
   @override
   void close() => client.close();
+}
+
+/// Sends [request] as a single HTTP/2 stream on [transport], translating
+/// between `BaseRequest`/`StreamedResponse` and http2's frames.
+Future<StreamedResponse> _sendOverHttp2(
+  ClientTransportConnection transport,
+  BaseRequest request,
+) async {
+  final bodyBytes = await request.finalize().toBytes();
+  final path = request.url.hasQuery
+      ? '${request.url.path}?${request.url.query}'
+      : request.url.path;
+
+  final stream = transport.makeRequest([
+    Header.ascii(':method', request.method),
+    Header.ascii(':scheme', 'https'),
+    Header.ascii(':authority', request.url.host),
+    Header.ascii(':path', path),
+    for (final entry in request.headers.entries)
+      Header.ascii(entry.key, entry.value),
+  ], endStream: bodyBytes.isEmpty);
+
+  if (bodyBytes.isNotEmpty) stream.sendData(bodyBytes, endStream: true);
+
+  final statusCompleter = Completer<int>();
+  final bodyController = StreamController<List<int>>();
+  final responseHeaders = <String, String>{};
+
+  stream.incomingMessages.listen(
+    (message) {
+      if (message is HeadersStreamMessage) {
+        for (final header in message.headers) {
+          final name = ascii.decode(header.name);
+          final value = ascii.decode(header.value);
+          if (name == ':status') {
+            if (!statusCompleter.isCompleted) {
+              statusCompleter.complete(int.parse(value));
+            }
+          } else {
+            responseHeaders[name] = value;
+          }
+        }
+      } else if (message is DataStreamMessage) {
+        bodyController.add(message.bytes);
+      }
+    },
+    onDone: () {
+      if (!bodyController.isClosed) bodyController.close();
+    },
+    onError: (Object error, StackTrace stackTrace) {
+      if (!statusCompleter.isCompleted) {
+        statusCompleter.completeError(error, stackTrace);
+      }
+      bodyController.addError(error, stackTrace);
+    },
+    cancelOnError: true,
+  );
+
+  final statusCode = await statusCompleter.future;
+  return StreamedResponse(
+    bodyController.stream,
+    statusCode,
+    headers: responseHeaders,
+    request: request,
+  );
+}
+
+class _PooledConnection {
+  _PooledConnection(this.transportFuture);
+  final Future<ClientTransportConnection> transportFuture;
+  int inFlight = 0;
+
+  /// Set once a send() on this connection throws - matches Node
+  /// ClientPool's RST_STREAM handling: stop routing NEW work here, but let
+  /// requests already in flight finish. Actually removing/closing failed
+  /// connections is deferred (see [Http2ClientPool] doc comment) - this
+  /// pass only stops reusing them.
+  bool failed = false;
+}
+
+/// Sends every request as a stream on a pool of shared HTTP/2 connections
+/// to [host], mirroring nodejs-firestore's `ClientPool`
+/// (dev/src/pool.ts): packs load onto the most-full connection under
+/// [maxStreamsPerConnection] (to keep others idle) rather than spreading
+/// evenly, opens a new connection once all existing ones are full, and
+/// stops routing new work to a connection once it's shown a
+/// connection-level failure.
+///
+/// Known gaps vs. Node's ClientPool, deferred to a follow-up:
+/// - No idle-capacity garbage collection - connections opened during a
+///   burst are never closed once traffic quiets down.
+/// - No graceful terminate() draining - close() does not wait for
+///   in-flight requests before finishing connections.
+///
+/// Pure transport: no auth. Wrapped with googleapis_auth's client helpers
+/// below (see [FirestoreHttpClient._createClient]) for a refreshing
+/// AuthClient.
+class Http2ClientPool extends BaseClient {
+  Http2ClientPool(this.host, {this.maxStreamsPerConnection = 100})
+    : _handshakeGate = Pool(_maxConcurrentHandshakes);
+
+  final String host;
+  final int maxStreamsPerConnection;
+
+  // Caps concurrent in-flight TCP+TLS handshakes, independent of how many
+  // total connections the pool ends up needing - protects against a huge,
+  // unpredictable production burst opening hundreds of handshakes at once.
+  static const _maxConcurrentHandshakes = 50;
+  final Pool _handshakeGate;
+
+  final List<_PooledConnection> _connections = [];
+
+  Future<ClientTransportConnection> _openConnection() {
+    return _handshakeGate.withResource(() async {
+      final socket = await SecureSocket.connect(
+        host,
+        443,
+        supportedProtocols: ['h2'],
+      );
+      if (socket.selectedProtocol != 'h2') {
+        throw StateError(
+          'Server did not negotiate HTTP/2 (got ${socket.selectedProtocol})',
+        );
+      }
+      return ClientTransportConnection.viaSocket(socket);
+    });
+  }
+
+  /// Picks the most-full connection under capacity, or reserves a new one.
+  ///
+  /// Deliberately synchronous (no `await`), so it runs atomically with
+  /// respect to other concurrent calls without needing a lock - otherwise
+  /// many callers arriving before the first connection finishes dialing
+  /// would all see an empty pool and each open their own (a thundering
+  /// herd), instead of piling onto the one already being established.
+  ///
+  /// "Most-full" (not least-loaded) selection matches Node ClientPool's
+  /// intent: pack load onto fewer connections so others stay idle and
+  /// become eligible for future cleanup, rather than spreading evenly.
+  _PooledConnection _acquireConnection() {
+    _PooledConnection? selected;
+    for (final conn in _connections) {
+      if (conn.failed) continue;
+      if (conn.inFlight < maxStreamsPerConnection &&
+          (selected == null || conn.inFlight > selected.inFlight)) {
+        selected = conn;
+      }
+    }
+    if (selected != null) return selected;
+
+    final pooled = _PooledConnection(_openConnection());
+    _connections.add(pooled);
+    return pooled;
+  }
+
+  /// The number of connections currently in the pool (including any that
+  /// have been marked [_PooledConnection.failed] but not yet cleaned up).
+  int get connectionCount => _connections.length;
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    final conn = _acquireConnection();
+    conn.inFlight++;
+    try {
+      final transport = await conn.transportFuture;
+      return await _sendOverHttp2(transport, request);
+    } catch (e) {
+      // Broader than Node's RST_STREAM-specific regex match - our own
+      // testing surfaced multiple distinct http2-level error shapes
+      // (REFUSED_STREAM, "forcefully terminated"/CONNECT_ERROR), so any
+      // thrown error here is treated as a signal this connection is no
+      // longer trustworthy for new work.
+      conn.failed = true;
+      rethrow;
+    } finally {
+      conn.inFlight--;
+    }
+  }
+
+  @override
+  void close() {
+    for (final conn in _connections) {
+      conn.transportFuture.then((t) => t.finish());
+    }
+  }
 }
 
 /// HTTP client wrapper for Firestore API operations.
@@ -157,21 +346,30 @@ class FirestoreHttpClient {
   /// Creates the appropriate HTTP client based on emulator configuration.
   Future<googleapis_auth.AuthClient> _createClient() async {
     if (_isUsingEmulator) {
-      // Emulator: Create unauthenticated client.
+      // Emulator: Create unauthenticated client. The emulator has no TLS
+      // and doesn't negotiate HTTP/2, so this stays on plain HTTP/1.1.
       return EmulatorClient(Client());
     }
 
-    // Production: Create authenticated client.
+    // Production: every request multiplexes over a pool of shared HTTP/2
+    // connections instead of dart:io's default one-connection-per-request
+    // HTTP/1.1 behavior. googleapis_auth wraps this transport with its
+    // token-refresh logic - the pool itself has no auth concept.
+    final transport = Http2ClientPool(_settings.host ?? 'firestore.googleapis.com');
+
     final serviceAccountCreds = credential.serviceAccountCredentials;
     if (serviceAccountCreds != null) {
-      return googleapis_auth.clientViaServiceAccount(serviceAccountCreds, [
-        'https://www.googleapis.com/auth/cloud-platform',
-      ]);
+      return googleapis_auth.clientViaServiceAccount(
+        serviceAccountCreds,
+        ['https://www.googleapis.com/auth/cloud-platform'],
+        baseClient: transport,
+      );
     }
 
     // Fall back to Application Default Credentials
     return googleapis_auth.clientViaApplicationDefaultCredentials(
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      baseClient: transport,
     );
   }
 

--- a/packages/google_cloud_firestore/pubspec.yaml
+++ b/packages/google_cloud_firestore/pubspec.yaml
@@ -19,8 +19,10 @@ dependencies:
   google_cloud_type: ^0.5.2
   googleapis_auth: ^2.3.3
   http: ^1.6.0
+  http2: ^2.3.1
   intl: ^0.20.0
   meta: ^1.17.0
+  pool: ^1.5.1
   retry: ^3.1.2
 
 dev_dependencies:

--- a/packages/google_cloud_firestore/test/http_client_test.dart
+++ b/packages/google_cloud_firestore/test/http_client_test.dart
@@ -1,0 +1,191 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:google_cloud_firestore/src/firestore_http_client.dart';
+import 'package:test/test.dart';
+
+ClientPool<int> _pool({
+  required int maxConcurrentOperations,
+  int maxIdleResources = 1,
+}) {
+  var nextId = 0;
+  return ClientPool<int>(
+    () async => nextId++,
+    maxConcurrentOperations: maxConcurrentOperations,
+    maxIdleResources: maxIdleResources,
+    destroy: (_) async {},
+  );
+}
+
+void main() {
+  group('ClientPool', () {
+    test('creates new resources as needed', () {
+      final pool = _pool(maxConcurrentOperations: 2);
+      final completers = List.generate(3, (_) => Completer<void>());
+
+      expect(pool.size, 0);
+      unawaited(pool.run((_) => completers[0].future));
+      unawaited(pool.run((_) => completers[1].future));
+      expect(pool.size, 1);
+      unawaited(pool.run((_) => completers[2].future));
+      expect(pool.size, 2);
+
+      for (final c in completers) {
+        c.complete();
+      }
+    });
+
+    test('re-uses a resource with remaining capacity', () async {
+      final pool = _pool(maxConcurrentOperations: 2);
+      final completers = List.generate(3, (_) => Completer<void>());
+
+      final first = pool.run((_) => completers[0].future);
+      unawaited(pool.run((_) => completers[1].future));
+      expect(pool.size, 1);
+
+      completers[0].complete();
+      await first;
+
+      unawaited(pool.run((_) => completers[2].future));
+      expect(pool.size, 1);
+
+      completers[1].complete();
+      completers[2].complete();
+    });
+
+    test('packs load onto the most-full resource', () async {
+      final pool = _pool(maxConcurrentOperations: 2);
+      final completers = List.generate(4, (_) => Completer<void>());
+      final resourcesUsed = <int>[];
+
+      void run(int i) =>
+          unawaited(pool.run((r) {
+            resourcesUsed.add(r);
+            return completers[i].future;
+          }));
+
+      run(0);
+      run(1);
+      run(2); // Resource 0 is full - this should open resource 1.
+      await Future<void>.value();
+      expect(resourcesUsed, [0, 0, 1]);
+
+      completers[0].complete();
+      await Future<void>.value();
+
+      run(3); // Resource 0 has a free slot again and is the most-full option.
+      await Future<void>.value();
+      expect(resourcesUsed, [0, 0, 1, 0]);
+
+      completers[1].complete();
+      completers[2].complete();
+      completers[3].complete();
+    });
+
+    test('stops reusing a resource after it fails', () async {
+      final pool = _pool(maxConcurrentOperations: 10);
+      final resourcesUsed = <int>[];
+
+      await pool
+          .run((r) {
+            resourcesUsed.add(r);
+            return Future<void>.error('boom');
+          })
+          .catchError((_) {});
+
+      await pool.run((r) {
+        resourcesUsed.add(r);
+        return Future<void>.value();
+      });
+
+      expect(resourcesUsed, [0, 1]);
+    });
+
+    test('garbage collects after success', () async {
+      final pool = _pool(maxConcurrentOperations: 2, maxIdleResources: 0);
+      final completers = List.generate(4, (_) => Completer<void>());
+
+      final ops = [
+        pool.run((_) => completers[0].future),
+        pool.run((_) => completers[1].future),
+        pool.run((_) => completers[2].future),
+        pool.run((_) => completers[3].future),
+      ];
+      expect(pool.size, 2);
+
+      for (final c in completers) {
+        c.complete();
+      }
+      await Future.wait(ops);
+
+      expect(pool.size, 0);
+    });
+
+    test('garbage collects after error', () async {
+      final pool = _pool(maxConcurrentOperations: 2, maxIdleResources: 0);
+
+      final ops = List.generate(
+        4,
+        (_) => pool.run((_) => Future<void>.error('boom')).catchError((_) {}),
+      );
+      await Future.wait(ops);
+
+      expect(pool.size, 0);
+    });
+
+    test('keeps a pool of idle resources up to maxIdleResources', () async {
+      final pool = _pool(maxConcurrentOperations: 1, maxIdleResources: 3);
+      final completers = List.generate(4, (_) => Completer<void>());
+
+      final ops = [
+        pool.run((_) => completers[0].future),
+        pool.run((_) => completers[1].future),
+        pool.run((_) => completers[2].future),
+        pool.run((_) => completers[3].future),
+      ];
+      expect(pool.size, 4);
+
+      for (final c in completers) {
+        c.complete();
+      }
+      await Future.wait(ops);
+
+      expect(pool.size, 3);
+    });
+
+    test('rejects operations after terminate()', () async {
+      final pool = _pool(maxConcurrentOperations: 1);
+
+      await pool.terminate();
+
+      expect(() => pool.run((_) async {}), throwsA(isA<StateError>()));
+    });
+
+    test('waits for in-flight operations before terminating', () async {
+      final pool = _pool(maxConcurrentOperations: 1);
+      final completer = Completer<void>();
+      var terminated = false;
+
+      unawaited(pool.run((_) => completer.future));
+      final terminateOp = pool.terminate().then((_) => terminated = true);
+
+      expect(terminated, isFalse);
+      completer.complete();
+      await terminateOp;
+      expect(terminated, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #297.

Dart's Firestore client used `dart:io`'s `HttpClient`, which only speaks HTTP/1.1, so every concurrent request opened its own TCP+TLS connection. At high concurrency this caused connection-storm failures (`ClientException`, `HandshakeException`) and made Dart much slower than Node, whose Firestore client multiplexes concurrent operations over a small pool of HTTP/2 connections.

Firestore traffic now goes over `package:http2`'s `Http2Client`, which packs requests onto shared connections under a 100-stream cap and dials another once those fill. It speaks only HTTP/2, so a small wrapper keeps the endpoints that are still plain HTTP on HTTP/1.1: the emulator, `Settings.ssl: false`, and the credential sources `googleapis_auth` reaches through the same base client, such as the GCE metadata server.

## Benchmark

| Concurrency | Run 1 | Run 2 | Run 3 |
|---|---|---|---|
| 3000 | 2438.35ms | 1602.67ms | 1245.91ms |
| 5000 | 2460.53ms | 2199.92ms | 2111.67ms |
| 10000 | 7195.02ms | 1518.93ms | 2180.65ms |
