### PR TITLE
chore(deps): group minor and patch action bumps, ignore codecov majors

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    # Wait a week before adopting a new release, so a compromised version has
+    # time to be pulled before it reaches CI.
+    cooldown:
+      default-days: 7
     groups:
       # Minor and patch bumps batch into a single PR. Majors are deliberately
       # left ungrouped so each gets its own PR and one blocked bump can't hold

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,18 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      all:
+      # Minor and patch bumps batch into a single PR. Majors are deliberately
+      # left ungrouped so each gets its own PR and one blocked bump can't hold
+      # back the rest.
+      minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # The org Actions allow-list only permits codecov/codecov-action@v4
+      # (see #306), so major bumps can never be merged here. Minor and patch
+      # updates within v4 still apply.
+      - dependency-name: "codecov/codecov-action"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Closing #319 didn't actually stop it — dependabot only records ignore state from an `ignore` rule, never from a closed grouped PR, so the same codecov v4 → v7 bump would have come back next month. Adds an ignore rule for codecov major versions, since the org Actions allow-list only permits `codecov/codecov-action@v4` (#306).

Also batches minor and patch bumps into a single PR and leaves majors ungrouped so each gets its own, rather than one unmergeable bump taking three fine ones down with it the way #319 did.

Adds a 7-day cooldown as well — the mandatory zizmor scan flags a dependabot config without one, and it gives a compromised release time to be pulled before it reaches CI.
